### PR TITLE
Add back dataset status nav and auto-expand when requested

### DIFF
--- a/ckanext/cfpb_extrafields/fanstatic/dataset-status.js
+++ b/ckanext/cfpb_extrafields/fanstatic/dataset-status.js
@@ -1,0 +1,5 @@
+"use strict"
+
+if (window.location.search.indexOf('view_id') > -1) {
+  $("#dataset-status .expandable").get(0).expand();
+}

--- a/ckanext/cfpb_extrafields/templates/package/resource_read.html
+++ b/ckanext/cfpb_extrafields/templates/package/resource_read.html
@@ -225,11 +225,10 @@ function example_code_snippet(items) {
   </div>
 </div>
       
-  {% endif %}
-{% block resource_view_nav %}
-{% endblock %}
+{% endif %}
 {% block resource_view_content %}
-<section class="module resource-view">
+{% resource 'cfpb_extrafields/dataset-status.js' %}
+<section class="module resource-view" id="dataset-status">
   <div class="module-content">
     <div class="expandable expandable__padded">
       <button class="expandable_header expandable_target" title="Expand content">
@@ -248,6 +247,9 @@ function example_code_snippet(items) {
           </span>
       </button>
       <div class="expandable_content">
+          {% block resource_view_nav %}
+            {{ super() }}
+          {% endblock %}
           {{ super() }}
       </div>
     </div>


### PR DESCRIPTION
@sleitner After writing all the cookie code I realized there's a much easier way to handle it: Check if there's a `view_id` parameter in the URL and open the dataset status section if there is.
