### PR TITLE
Improve contenteditable experience

### DIFF
--- a/ckanext/cfpb_extrafields/fanstatic/ckan_overrides.css
+++ b/ckanext/cfpb_extrafields/fanstatic/ckan_overrides.css
@@ -321,6 +321,12 @@ input[type="button"].btn-block {
   margin-right: 0;
 }
 
+/* Data dicts */
+
+.dict-new-row {
+  border: 1px dashed #ccc;
+}
+
 /* Footer */
 
 #creeper {

--- a/ckanext/cfpb_extrafields/templates/package/snippets/resource_type-specific/cfpb_extrafields_datadictionary.html
+++ b/ckanext/cfpb_extrafields/templates/package/snippets/resource_type-specific/cfpb_extrafields_datadictionary.html
@@ -55,7 +55,7 @@ X related-to-url
   <table class="table">
     <tr>
       {% for item in header_names %}
-        <th contenteditable={{editable}}>{{ item }}</th>
+        <th><div contenteditable={{editable}}>{{ item }}</div></th>
       {% endfor %}
       {% if editable == "true" %}
       <th></th>
@@ -66,7 +66,7 @@ X related-to-url
     <tr>
       {% for i in nkeys %}
         {% set key = header_keys[i]%}
-          <td contenteditable={{editable}}>{{ dd[irow][key] }}</td>
+          <td><div contenteditable={{editable}}>{{ dd[irow][key] }}</div></td>
         {% endfor %}
       {% if editable == "true" %}
       <td>
@@ -82,7 +82,7 @@ X related-to-url
    <!-- This is our hidden clonable table line -->
     <tr class="hide">
       {% for item in header_names %}
-        <td contenteditable={{editable}}>-</td>
+        <td><div contenteditable={{editable}} class="dict-new-row"></div></td>
       {% endfor %}
       <td>
         <span class="table-remove"><button type='button' class="btn btn-danger"><i class="icon-trash icon-single"></i></button></span>


### PR DESCRIPTION
IE doesn't support contenteditable on table cells so the trick is to insert an inner element that's editable.
